### PR TITLE
Se usa un solo modal para eliminar las notas

### DIFF
--- a/src/Notas/components/NotaView.js
+++ b/src/Notas/components/NotaView.js
@@ -1,21 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Card, Row, Col } from 'react-bootstrap';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { IconButton } from '@mui/material/';
-import { useDispatch } from 'react-redux';
 
-import ModalConfirmacion from '../../utilities/ModalConfirmacion';
-import { DELETE_NOTA } from '../actionTypes';
 
-function NotaView({ nota }) {
-
-    const dispatch = useDispatch();
-    const borrarNota = (nota) => dispatch({ type: DELETE_NOTA, parameters: { id: nota.id } });
-
-    const [show, setShow] = useState(false);
-    const closeModal = () => setShow(false);
-    const showModal = () => setShow(true);
+function NotaView({ nota, showModal, setNotaDelete }) {
     return (
         <div>
             <Card className='mt-4 bg-warning overflow-auto' style={{width: '18rem', height: '10rem'}}>
@@ -28,14 +18,13 @@ function NotaView({ nota }) {
                     </Card.Text>
                     <Row className='justify-content-end'>
                         <Col xs={ 3 }>
-                            <IconButton onClick={ () => showModal() }>
+                            <IconButton onClick={ () => {showModal(); setNotaDelete(nota)}}>
                                 <DeleteOutlineIcon/>
                             </IconButton>
                         </Col>
                     </Row>
                 </Card.Body>
-            </Card>
-            <ModalConfirmacion show={ show } closeModal={ closeModal } success={ () => borrarNota(nota) }/>
+            </Card>            
         </div>
     );
 }

--- a/src/Notas/components/NotasContainer.js
+++ b/src/Notas/components/NotasContainer.js
@@ -1,20 +1,32 @@
-import React from 'react';
-
+import React, { useState } from 'react';
 import NotaView from './NotaView';
 import { Container, Col, Row } from 'react-bootstrap';
+import ModalConfirmacion from '../../utilities/ModalConfirmacion';
+import { useDispatch } from 'react-redux';
+import { DELETE_NOTA } from '../actionTypes';
 
 function NotasContainer({ notas }) {
+    const dispatch = useDispatch();
+    const borrarNota = (nota) => dispatch({ type: DELETE_NOTA, parameters: { id: nota.id } });
+
+    const [show, setShow] = useState(false);
+    const closeModal = () => setShow(false);
+    const showModal = () => setShow(true);
+
+    const [notaDelete, setNotaDelete] = useState({});
+
     return (
         <Container fluid='xl'>
             <Row className='mb-4'>
                 {  
                     notas.map((nota, id) => 
                     <Col md={ 6 } xl={ 4 } key={ id } className='d-flex justify-content-center'> 
-                        <NotaView nota={ nota }/>
+                        <NotaView nota={ nota } setNotaDelete={setNotaDelete} showModal={ showModal }/>
                     </Col>
                     )
                 } 
-            </Row>     
+            </Row>  
+            <ModalConfirmacion show={ show } closeModal={ closeModal } success={ () => borrarNota(notaDelete) }/>   
         </Container>
     );
 }


### PR DESCRIPTION
Arregle el hecho de que por cada nota individual de las notas guardadas en la base de datos antes se hacía un modal por cada una de ellas.